### PR TITLE
Fixes output not matching jUnit XSD.

### DIFF
--- a/src/Command/ErrorFormatter/JUnitErrorFormatter.php
+++ b/src/Command/ErrorFormatter/JUnitErrorFormatter.php
@@ -46,39 +46,40 @@ class JUnitErrorFormatter implements ErrorFormatter
                 $fileErrors[$fileSpecificError->getFile()][] = $fileSpecificError;
             }
 
-            foreach ($fileErrors as $file => $errors) {
-                $testcase = $dom->createElement('testcase');
-                $testcase->setAttribute('name', $this->relativePathHelper->getRelativePath($file));
-                $testcase->setAttribute('failures', (string)count($errors));
-                $testcase->setAttribute('errors', '0');
-                $testcase->setAttribute('tests', (string)count($errors));
+            $errorCount = 0;
 
+            foreach ($fileErrors as $file => $errors) {
                 foreach ($errors as $error) {
+                    $errorCount += 1;
+                    $testcase = $dom->createElement('testcase');
+                    $testcase->setAttribute('name', $this->relativePathHelper->getRelativePath($file));
+
                     $failure = $dom->createElement('failure');
                     $failure->setAttribute('type', 'error');
                     $failure->setAttribute('message', sprintf('%s on line %d', $error->getMessage(), $error->getLine()));
                     $testcase->appendChild($failure);
+                    $testsuite->appendChild($testcase);
                 }
 
-                $testsuite->appendChild($testcase);
             }
 
             $genericErrors = $analysisResult->getNotFileSpecificErrors();
             if (!empty($genericErrors)) {
-                $testcase = $dom->createElement('testcase');
-                $testcase->setAttribute('name', 'Generic Failures');
-                $testcase->setAttribute('failures', (string)count($genericErrors));
-                $testcase->setAttribute('errors', '0');
-                $testcase->setAttribute('tests', (string)count($genericErrors));
                 foreach ($genericErrors as $genericError) {
+                    $errorCount += 1;
+                    $testcase = $dom->createElement('testcase');
+                    $testcase->setAttribute('name', 'Generic Failures');
                     $failure = $dom->createElement('failure');
                     $failure->setAttribute('type', 'error');
                     $failure->setAttribute('message', $genericError);
                     $testcase->appendChild($failure);
+                    $testsuite->appendChild($testcase);
                 }
 
-                $testsuite->appendChild($testcase);
             }
+            $testsuite->setAttribute('failures', (string)$errorCount);
+            $testsuite->setAttribute('errors', '0');
+            $testsuite->setAttribute('tests', (string)$errorCount);
         }
 
         $dom->formatOutput = true;


### PR DESCRIPTION
Moves `failures`, `errors`, and `tests` attributes from `testcase`
element to `testsuite` element.
Places each new `failure` element in a new `testcase` element. Multiple
`failure` elements per `testcase` seems to be allowed by the spec, but
applications seem not to accept it. See:
https://github.com/junit-team/junit5/blob/master/platform-tests/src/test/resources/jenkins-junit.xsd
Lines 90-92

Fixes: https://github.com/mglaman/phpstan-junit/issues/2